### PR TITLE
style: Improved minor styling of accounts page

### DIFF
--- a/components/accounts/components/accounts-list.tsx
+++ b/components/accounts/components/accounts-list.tsx
@@ -1,10 +1,10 @@
-import React, { ComponentProps } from "react";
+import React from "react";
 import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import { ChevronRight } from "lucide-react";
 
 import { formatCurrency } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 import { Mail } from "../data";
@@ -39,17 +39,19 @@ export function AccountsList({ items }: MailListProps) {
               <Card
                 key={item.id}
                 onClick={() => setMail({ ...mail, selected: item.id })}
-                className="group flex items-center justify-between p-3 hover:bg-gray-100"
+                className="flex items-center justify-between p-3 group hover:bg-gray-100/10"
               >
-                <div className="flex grow flex-col">
-                  <CardTitle className="font-bold">{item.name}</CardTitle>
+                <div className="flex flex-col grow">
+                  <CardTitle className="font-bold text-md">
+                    {item.name}
+                  </CardTitle>
                   <p className="text-sm text-gray-500">
                     {formatDistanceToNow(new Date(item.date), {
                       addSuffix: true,
                     })}
                   </p>
                 </div>
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center space-x-4">
                   <Badge
                     variant={item.change >= 0 ? "default" : "destructive"}
                     className="self-start"
@@ -58,10 +60,10 @@ export function AccountsList({ items }: MailListProps) {
                       ? `▲ ${item.change}%`
                       : `▼ ${Math.abs(item.change)}%`}
                   </Badge>
-                  <p className="flex-1 truncate text-sm font-medium">
+                  <p className="flex-1 text-sm font-medium truncate">
                     {formatCurrency(item.available)}
                   </p>
-                  <ChevronRight className="h-5 w-5 text-gray-400" />
+                  <ChevronRight className="w-5 h-5 text-gray-400" />
                 </div>
               </Card>
             ))}

--- a/components/accounts/components/accounts-review-table.tsx
+++ b/components/accounts/components/accounts-review-table.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import * as React from "react";
-import {
-  CaretSortIcon,
-  ChevronDownIcon,
-  DotsHorizontalIcon,
-} from "@radix-ui/react-icons";
+import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -25,30 +21,19 @@ import {
   Building,
   Car,
   Check,
-  CreditCard,
   Divide,
   Mail,
   MessageSquare,
   PlusCircle,
   Repeat2,
-  Settings,
   ShoppingCartIcon,
-  UserPlus,
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -59,7 +44,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -168,7 +152,7 @@ export const columns: ColumnDef<Payment>[] = [
         currency: "USD",
       }).format(amount);
 
-      return <div className="text-right font-medium">{formatted}</div>;
+      return <div className="font-medium text-right">{formatted}</div>;
     },
   },
   {
@@ -180,9 +164,9 @@ export const columns: ColumnDef<Payment>[] = [
       return (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-8 w-8 p-0">
+            <Button variant="ghost" className="w-8 h-8 p-0">
               <span className="sr-only">Open menu</span>
-              <DotsHorizontalIcon className="h-4 w-4" />
+              <DotsHorizontalIcon className="w-4 h-4" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
@@ -190,37 +174,37 @@ export const columns: ColumnDef<Payment>[] = [
             <DropdownMenuItem
               onClick={() => navigator.clipboard.writeText(payment.id)}
             >
-              <Check className="mr-2 h-4 w-4" />
+              <Check className="w-4 h-4 mr-2" />
               <span>Review</span>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem>
-              <Divide className="mr-2 h-4 w-4" />
+              <Divide className="w-4 h-4 mr-2" />
               <span>Split</span>
             </DropdownMenuItem>
             <DropdownMenuItem>
-              <Repeat2 className="mr-2 h-4 w-4" />
+              <Repeat2 className="w-4 h-4 mr-2" />
               <span>Recurring</span>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
-                <ArrowRightLeftIcon className="mr-2 h-4 w-4" />
+                <ArrowRightLeftIcon className="w-4 h-4 mr-2" />
                 <span>Transaction Type</span>
               </DropdownMenuSubTrigger>
               <DropdownMenuPortal>
                 <DropdownMenuSubContent>
                   <DropdownMenuItem>
-                    <Mail className="mr-2 h-4 w-4" />
+                    <Mail className="w-4 h-4 mr-2" />
                     <span>Internal transfer</span>
                   </DropdownMenuItem>
                   <DropdownMenuItem>
-                    <MessageSquare className="mr-2 h-4 w-4" />
+                    <MessageSquare className="w-4 h-4 mr-2" />
                     <span>Regular</span>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem>
-                    <PlusCircle className="mr-2 h-4 w-4" />
+                    <PlusCircle className="w-4 h-4 mr-2" />
                     <span>More...</span>
                   </DropdownMenuItem>
                 </DropdownMenuSubContent>

--- a/components/accounts/components/mail.tsx
+++ b/components/accounts/components/mail.tsx
@@ -1,50 +1,27 @@
 "use client"
-import * as React from "react"
 import {
-  AlertCircle,
-  Archive,
-  ArchiveX,
-  File,
-  Inbox,
-  MessagesSquare,
-  PenBox,
-  Search,
-  Send,
-  ShoppingCart,
-  Trash2,
-  Users2,
-  CreditCard,
-  Layers,
-  LayoutDashboard,
-  BarChart,
-  Tag,
-  Repeat2,
-  DollarSign,
-  PiggyBank,
-  Building,
-  Briefcase,
-  BadgeDollarSign,
-  HelpCircle,
-  Settings,
+  BadgeDollarSign, BarChart, Briefcase, Building, CreditCard, DollarSign, HelpCircle, Layers,
+  LayoutDashboard, PiggyBank, Repeat2, Search, Settings, Tag
 } from "lucide-react"
+import * as React from "react"
 
-import { AccountsList } from "./accounts-list"
-import { Nav } from "./nav"
-import { AccountSwitcher } from "./account-switcher"
-import { AccountsDisplay } from "./accounts-display"
-import { cn } from "@/lib/utils"
-import { Separator } from "@/components/ui/separator"
 import { Input } from "@/components/ui/input"
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable"
+import { Separator } from "@/components/ui/separator"
 import {
   Tabs,
   TabsContent,
   TabsList,
-  TabsTrigger,
+  TabsTrigger
 } from "@/components/ui/tabs"
 import { TooltipProvider } from "@/components/ui/tooltip"
-import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable"
+import { cn } from "@/lib/utils"
 import { Mail } from "../data"
 import { useMail } from "../use-mail"
+import { AccountSwitcher } from "./account-switcher"
+import { AccountsDisplay } from "./accounts-display"
+import { AccountsList } from "./accounts-list"
+import { Nav } from "./nav"
 
 interface MailProps {
   accounts: {


### PR DESCRIPTION
**What has been done**:

- improved hover color from the previous white it was, making it unreadable.
- title sizing changed giving it a nicer visual look.
- increased spacing of elements on the right side
- removed un-used imports + allowed my VScode to organize them better on file save.

**With the upcoming landing page + massive UI change, these changes will do for now as I'm sure everything will be changing down the line.**

But at least it's actually reasonably nice now.

**Unrelated suggestion**:

- Allow .vscode with settings.json - so we can unify appropriate measures for prettifying, removing un-used imports, and other actions on file saving to cleanup etc..

<img width="1375" alt="Screenshot 2024-01-04 at 12 08 33 AM" src="https://github.com/meglerhagen/projectx/assets/33054370/e33e62a0-fb49-4058-8ae4-83e0fbc8c02b">
