### PR TITLE
chore(EdgeStore): fix missing api keys for uploads api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,9 @@ NEXT_PUBLIC_STRIPE_PRO_YEARLY_PLAN_ID=
 
 NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PLAN_ID=
 NEXT_PUBLIC_STRIPE_BUSINESS_YEARLY_PLAN_ID=
+
+# -----------------------------------------------------------------------------
+# Uploads (EdgeStore)
+# -----------------------------------------------------------------------------
+EDGE_STORE_ACCESS_KEY=
+EDGE_STORE_SECRET_KEY=

--- a/env.mjs
+++ b/env.mjs
@@ -15,6 +15,8 @@ export const env = createEnv({
     TEST_EMAIL_ADDRESS: z.string().min(1),
     STRIPE_API_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
+    EDGE_STORE_ACCESS_KEY: z.string().min(1),
+    EDGE_STORE_SECRET_KEY: z.string().min(1),
   },
   client: {
     NEXT_PUBLIC_APP_URL: z.string().min(1),
@@ -40,5 +42,9 @@ export const env = createEnv({
     NEXT_PUBLIC_STRIPE_PRO_YEARLY_PLAN_ID: process.env.NEXT_PUBLIC_STRIPE_PRO_YEARLY_PLAN_ID,
     NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PLAN_ID: process.env.NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PLAN_ID,
     NEXT_PUBLIC_STRIPE_BUSINESS_YEARLY_PLAN_ID: process.env.NEXT_PUBLIC_STRIPE_BUSINESS_YEARLY_PLAN_ID,
+    // EdgeStore
+    EDGE_STORE_ACCESS_KEY: process.env.EDGE_STORE_ACCESS_KEY,
+    EDGE_STORE_SECRET_KEY: process.env.EDGE_STORE_SECRET_KEY,
+
   },
 })


### PR DESCRIPTION
**Bug**

The code base initialize a third party service `EdgeStore` to handle file uploads. Though the `env` variables for its api keys are not declared.

This result in a `500` error in the console when loading a page.

**Fix**

Add missing API keys ([doc](https://edgestore.dev/docs/quick-start))