### PR TITLE
Improvement: SVG logo for table Investment Dashboard

### DIFF
--- a/components/investments/components/holdings-table.tsx
+++ b/components/investments/components/holdings-table.tsx
@@ -103,7 +103,7 @@ const data = [
   },
   {
     id: "5",
-    name: "Google (Alphabet Inc.)",
+    name: "Alphabet Inc.(Google)",
     ticker: "GOOGL",
     current: 280,
     totalpercentage: 15,
@@ -148,6 +148,12 @@ const iconMap = {
   Coffee: <CoffeeIcon className="mr-2 h-5 w-5" />,
   // ... add other icon mappings
 };
+const iconMaptoCDN = (iconName: string) => {
+  const sanitizedWord = iconName
+    .split(/\W+/)[0]
+    .toLowerCase();
+  return <img className="mr-2 h-5 w-5" src={`https://s3-symbol-logo.tradingview.com/${sanitizedWord}--big.svg`} alt={`${sanitizedWord}`} />
+};
 
 export const columns: ColumnDef<Category>[] = [
   {
@@ -157,6 +163,7 @@ export const columns: ColumnDef<Category>[] = [
       const name = row.getValue("name") as string;
       return (
         <div className="flex items-center">
+          {iconMaptoCDN(name)}
           <div className="capitalize">{name}</div>
         </div>
       );


### PR DESCRIPTION
Its a dead simple solution for  https://github.com/meglerhagen/projectx/issues/30

Using TradingView CDN. Following are the benefits:
- No need to manually fix SVG icons for each company.
- As its colorful, we dont need to do anything extra for dark mode for now.


Going ahead we can have manually add these SVG icons and configure the color as per dark/light mode.



<img width="2008" alt="Screenshot 2024-01-04 at 15 26 21" src="https://github.com/meglerhagen/projectx/assets/4746256/9fb55938-b69e-49bc-9ea0-7ecd0e320845">
<img width="2039" alt="Screenshot 2024-01-04 at 15 29 02" src="https://github.com/meglerhagen/projectx/assets/4746256/7d068d58-eede-4e41-a0c3-8986935cec5d">
